### PR TITLE
ブログ投稿詳細の表示

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -12,5 +12,17 @@ class PostController extends Controller
         //$postテーブルの全データを"posts"という変数に入れて、postsフォルダにある"index.blade.php"（View）に渡す
         return view('posts.index')->with(['posts' => $post->getPaginateByLimit()]);
     }
+    
+    /**
+     * 特定IDのpostを表示する
+    *
+    * @params Object Post // 引数の$postはid=1のPostインスタンス
+    * @return Reposnse post view
+    */
+    public function show(Post $post)
+    {
+        //'post'はbladeファイルで使う変数。中身は$postはid=1のPostインスタンス。
+        return view('posts.show')->with(['post' => $post]);
+    }
 }
 ?>

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -11,7 +11,7 @@ class Post extends Model
     
     public function getPaginateByLimit(int $limit_count = 5)
     {
-    // updated_atで降順に並べたあと、limitで件数制限をかける
-    return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+        // updated_atで降順に並べたあと、limitで件数制限をかける
+        return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
     }
 }

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -11,8 +11,9 @@
         <div class='posts'>
             @foreach ($posts as $post) <!-- $posts内の配列データを$postという変数名で取得できる -->
                 <div class='post'>
-                    <h2 class='title'>{{ $post->title }}</h2>
-                    <p class='body'>{{ $post->body }}</p>
+                    <h2 class='title'>
+                        <a href="/posts/{{ $post->id }}">{{ $post->title }}</a>
+                    </h2>
                 </div>
             @endforeach
         </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<html lang="ja">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Posts</title>
+        <!-- Fonts -->
+        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+    </head>
+    <body>
+        <h1 class="title">
+            {{ $post->title }}
+        </h1>
+        <div class="content">
+            <div class="content__post">
+                <h3>本文</h3>
+                <p>{{ $post->body }}</p>    
+            </div>
+        </div>
+        <div class="footer">
+            <a href="/">戻る</a>
+        </div>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,9 +14,15 @@ use App\Http\Controllers\PostController;
 |
 */
 
-//"/"を受けとると、PostControllerというクラス内のindexメソッドを返す
-Route::get('/', [PostController::class, 'index']);
-
+//8-1
 /*Route::get('/', function() {
     return view('posts.index');
 });*/
+
+//8-2
+//"/"を受けとると、PostControllerというクラス内のindexメソッドを返す
+Route::get('/', [PostController::class, 'index']);
+
+//8-3
+// '/posts/{対象データのID}'にGetリクエストが来たら、PostControllerのshowメソッドを実行する
+Route::get('/posts/{post}', [PostController::class ,'show']);


### PR DESCRIPTION
１．ルーティング設定
・「https://〜〜〜/posts/(対象データID)」のURLでGETリクエストのアクセスが来たら、PostControllerのshow関数が実行されるルーティング定義の追加
・ルートパラメータの使用
２．Controller
・PostControllerにブログ投稿詳細画面表示用のshow関数を追加
・show関数で対象のpostsテーブルデータを取得し、show.blade.phpに引き継ぎ
３．View
・show.blade.phpにて引き継いだデータを適切に表示
・一覧に表示されるタイトルをリンクに変更→クリックで詳細画面に遷移