### PR TITLE
ブログ投稿の削除処理実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -22,7 +22,7 @@ class PostController extends Controller
     */
     public function show(Post $post)
     {
-        //'post'はbladeファイルで使う変数。中身は$postはid=1のPostインスタンス。
+        //'post'はbladeファイルで使う変数。中身は任意のidにおけるPostデータをインスタンス化した$post。
         return view('posts.show')->with(['post' => $post]);
     }
     
@@ -50,6 +50,12 @@ class PostController extends Controller
         $post->fill($input_post)->save();
         
         return redirect('/posts/' . $post->id);
+    }
+    
+    public function delete(Post $post)
+    {
+        $post->delete();
+        return redirect('/');
     }
 }
 ?>

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
     use HasFactory;
+    use SoftDeletes;
     
     protected $fillable = [
         'title',

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -8,18 +8,33 @@
     </head>
     <body>
         <h1>Blog Name</h1>
-        <a href="/posts/create">create</a>
+        <a href="/posts/create">作成する</a>
         <div class='posts'>
             @foreach ($posts as $post) <!-- $posts内の配列データを$postという変数名で取得できる -->
                 <div class='post'>
                     <h2 class='title'>
                         <a href="/posts/{{ $post->id }}">{{ $post->title }}</a>
                     </h2>
+                    <p class='body'>{{ $post->body }}</p>
+                    <form action="/posts/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
+                        @csrf
+                        @method('DELETE')
+                        <button type="button" onclick="deletePost({{ $post->id }})">delete</button> 
+                    </form>
                 </div>
             @endforeach
         </div>
         <div class='paginate'>
             {{ $posts->links() }}
         </div>
+        <script>
+            function deletePost(id) {
+                'use strict'
+                
+                if(confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                    document.getElementById(`form_${id}`).submit();
+                }
+            }
+        </script>
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,3 +34,6 @@ Route::get('/posts/{post}', [PostController::class ,'show']);
 //8-5
 Route::get('/posts/{post}/edit', [PostController::class, 'edit']);
 Route::put('/posts/{post}', [PostController::class, 'update']);
+
+//8-6
+Route::delete('/posts/{post}', [PostController::class,'delete']);


### PR DESCRIPTION
１．ブログ投稿一覧画面へのブログ投稿削除実行用導線追加
・各投稿毎に削除ボタンを追加し、ボタン押下するとJavaScriptにて削除確認のダイアログを表示
ダイアログで「OK」を選択した場合は、https://〜〜〜/posts/(対象データID)のURLでDELETEリクエストを実行
「キャンセル」の場合は何も行わない

２．ブログ投稿削除実行用のコントローラー実装、ルーティング追加
・PostControllerにブログ投稿削除実行用のdelete関数を追加
・delete関数にて、以下の処理を実装
  ・postsテーブルの対象データを論理削除。
  ・削除完了後、https://〜〜〜/postsのURLにリダイレクトを行う。
・https://〜〜〜/posts/(対象データID)のURLでDELETEリクエストのアクセスが来たら、PostControllerのdelete関数が実行されるルーティング定義の追加

３．ブログ投稿用モデルクラス修正
Postモデルクラス（Post.php）で以下の二つを行う
・class定義より前のuse定義にuse Illuminate\Database\Eloquent\SoftDeletes;を追加。
・class定義直後にuse SoftDeletes;を追加。

追加前：
発行されるSQLがDELETE文になる
追加後：
発行されるSQLがUPDATE文になり、deleted_atに実行日時が設定される
論理削除が有効になっているモデルでは、deleted_atに値が設定されると以降は削除扱いとなり、検索等で引っかからないようになる